### PR TITLE
Call customBlockHandler before to be able to override supported styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,7 @@
 // @flow
 
 import getRNDraftJSBlocks from './src/getBlocks';
+import DraftJsText from './src/components/DraftJsText';
 
-module.exports = getRNDraftJSBlocks;
+export default getRNDraftJSBlocks;
+export { DraftJsText };

--- a/src/getBlocks.js
+++ b/src/getBlocks.js
@@ -199,4 +199,4 @@ const getBlocks = (params: ParamsType): ?Array<*> => {
     });
 };
 
-module.exports = getBlocks;
+export default getBlocks;

--- a/src/getBlocks.js
+++ b/src/getBlocks.js
@@ -92,6 +92,17 @@ const getBlocks = (params: ParamsType): ?Array<*> => {
         entityRanges: item.entityRanges,
       };
 
+      const customView = customBlockHandler ? customBlockHandler(item, params) : undefined;
+      if (customView) {
+        const viewBefore = checkCounter(counters);
+        return (
+          <View key={generateKey()}>
+            {viewBefore}
+            {customView}
+          </View>
+        );
+      }
+
       switch (item.type) {
         case 'unstyled':
         case 'paragraph':
@@ -178,7 +189,7 @@ const getBlocks = (params: ParamsType): ?Array<*> => {
 
         default: {
           const viewBefore = checkCounter(counters);
-          return customBlockHandler ? customBlockHandler(item, params) : (
+          return (
             <View key={generateKey()}>
               {viewBefore}
             </View>


### PR DESCRIPTION
I would like to customize the way some blocks are rendered (especially, headings and blockquotes). Right now, "header-*" are necessarily rendered as a DraftJsText and "blockquote-*" have a fixed layout with a container view, a DraftJsText, an icon before and an icon after. Unfortunately, this does not match the design I'd like to implement.

This pull-request allows to implement customBlockHandler to override the rendering of any styles, allowing further customization of their layout.