### PR TITLE
Text alignment typo fix

### DIFF
--- a/sample/__tests__/components/DraftJsText.test.js
+++ b/sample/__tests__/components/DraftJsText.test.js
@@ -76,7 +76,7 @@ it('extends a style with a customStyle from another type', () => {
 
 it('renders text-align: left', () => {
   const text = 'Hello World';
-  const data = { 'text-align': 'left' };
+  const data = { 'textAlignment': 'left' };
   const tree = renderer.create(<DraftJsText
     type="paragraph"
     text={text}
@@ -90,7 +90,7 @@ it('renders text-align: left', () => {
 
 it('renders text-align: right', () => {
   const text = 'Hello World';
-  const data = { 'text-align': 'right' };
+  const data = { 'textAlignment': 'right' };
   const tree = renderer.create(<DraftJsText
     type="paragraph"
     text={text}
@@ -104,7 +104,7 @@ it('renders text-align: right', () => {
 
 it('renders text-align: center', () => {
   const text = 'Hello World';
-  const data = { 'text-align': 'center' };
+  const data = { 'textAlignment': 'center' };
   const tree = renderer.create(<DraftJsText
     type="paragraph"
     text={text}

--- a/sample/__tests__/components/DraftJsText.test.js
+++ b/sample/__tests__/components/DraftJsText.test.js
@@ -76,7 +76,7 @@ it('extends a style with a customStyle from another type', () => {
 
 it('renders text-align: left', () => {
   const text = 'Hello World';
-  const data = { 'textAlignment': 'left' };
+  const data = { textAlignment: 'left' };
   const tree = renderer.create(<DraftJsText
     type="paragraph"
     text={text}
@@ -90,7 +90,7 @@ it('renders text-align: left', () => {
 
 it('renders text-align: right', () => {
   const text = 'Hello World';
-  const data = { 'textAlignment': 'right' };
+  const data = { textAlignment: 'right' };
   const tree = renderer.create(<DraftJsText
     type="paragraph"
     text={text}
@@ -104,7 +104,7 @@ it('renders text-align: right', () => {
 
 it('renders text-align: center', () => {
   const text = 'Hello World';
-  const data = { 'textAlignment': 'center' };
+  const data = { textAlignment: 'center' };
   const tree = renderer.create(<DraftJsText
     type="paragraph"
     text={text}

--- a/src/components/DraftJsText.js
+++ b/src/components/DraftJsText.js
@@ -30,7 +30,7 @@ const DraftJsText = (props: DraftJsTextPropsType): any => {
     });
 
     const customStyle = props.customStyles ? props.customStyles[props.type] : undefined;
-    const textAlignStyle = { textAlign: props.data['textAlignment'] };
+    const textAlignStyle = { textAlign: props.data.textAlignment };
 
     return (
       <Text

--- a/src/components/DraftJsText.js
+++ b/src/components/DraftJsText.js
@@ -30,7 +30,7 @@ const DraftJsText = (props: DraftJsTextPropsType): any => {
     });
 
     const customStyle = props.customStyles ? props.customStyles[props.type] : undefined;
-    const textAlignStyle = { textAlign: props.data['text-align'] };
+    const textAlignStyle = { textAlign: props.data['textAlignment'] };
 
     return (
       <Text


### PR DESCRIPTION
Text alignment does not work.
Wrong key is used. Draft js uses `textAlignment`
https://draftjs.org/docs/advanced-topics-text-direction#text-alignment